### PR TITLE
Update ci.yml to Node 16 and add write permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,8 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: 3.x
       - run: pip install mkdocs-material

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,8 @@ on:
     branches:
       - master
       - main
+permissions:
+  contents: write
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Related to issues #30 #26 #25 #24

#28 and #25 have another solution to change all action permissions, but I think my fix requires less set-up and is more secure by not granting write access to all actions. 

I've also upgraded it to use Node 16 as Node 12 will be deprecated by Summer 2023. 